### PR TITLE
feat: find task by id

### DIFF
--- a/src/controllers/TaskController.ts
+++ b/src/controllers/TaskController.ts
@@ -17,7 +17,7 @@ export default class TaskController {
             res.status(201).send(result);
         } catch (err: any) {
             const error = err as Error;
-            res.status(400).send(error.message);
+            res.status(400).send(error);
         }
     }
 
@@ -27,7 +27,18 @@ export default class TaskController {
             res.status(200).send(result);
         } catch (err: any) {
             const error = err as Error;
-            res.status(400).send(error.message);
+            res.status(400).send(error);
+        }
+    }
+
+    public async getTaskById(req: Request, res: Response) {
+        const id = req.params.id;
+        try {
+            const result = await this.service.findById(Number(id));
+            res.status(200).send(result);
+        } catch (err: any) {
+            const error = err as Error;
+            res.status(404).send({ message: error.message });
         }
     }
 }

--- a/src/repositories/InMemoTaskRepository.ts
+++ b/src/repositories/InMemoTaskRepository.ts
@@ -21,4 +21,15 @@ export default class InMemoTaskRepository implements Repository<Task> {
             resolve(tasks);
         });
     }
+
+    async findById(id: number): Promise<Task | null> {
+        return new Promise<Task | null>((resolve, _) => {
+            const taskFound = this.items.find(task => task.id === id);
+            if (taskFound) {
+                resolve(taskFound);
+            } else {
+                resolve(null);
+            }
+        });
+    }
 }

--- a/src/repositories/Repository.ts
+++ b/src/repositories/Repository.ts
@@ -3,4 +3,5 @@ export default interface Repository<T> {
 
     save(item: T): Promise<T>;
     findAll(): Promise<T[]>;
+    findById(id: number): Promise<T | null>;
 }

--- a/src/routes/taskRouter.ts
+++ b/src/routes/taskRouter.ts
@@ -8,5 +8,6 @@ const controller = new TaskController(new TaskService(new InMemoTaskRepository()
 
 taskRouter.post('/', (req: Request, res: Response) => controller.createTask(req, res));
 taskRouter.get('/', (req: Request, res: Response) => controller.getAllTasks(req, res));
+taskRouter.get('/:id', (req: Request, res: Response) => controller.getTaskById(req, res));
 
 export default taskRouter;

--- a/src/services/TaskService.ts
+++ b/src/services/TaskService.ts
@@ -2,6 +2,7 @@ import Task from '../entities/Task';
 import Repository from "../repositories/Repository";
 import NewTaskDTO from "../controllers/dtos/NewTaskDTO";
 import CreatedTask from "../controllers/dtos/CreatedTask";
+import TaskNotFound from "./errors/TaskNotFound";
 
 export default class TaskService {
     repository: Repository<Task>;
@@ -17,7 +18,17 @@ export default class TaskService {
     }
 
     async findAll(): Promise<CreatedTask[]> {
-        const result = await this.repository.findAll();
-        return result.map(task => new CreatedTask(task.name, task.description, task.createdAt, task.dueDate, task.isDone));
+        return await this.repository.findAll();
+        // return result.map(task => new CreatedTask(task.name, task.description, task.createdAt, task.dueDate, task.isDone));
+    }
+
+    async findById(id: number): Promise<CreatedTask | null> {
+        const result = await this.repository.findById(id);
+        if (result) {
+            return new CreatedTask(result.name, result.description, result.createdAt, result.dueDate, result.isDone);
+        }
+        else {
+            throw new TaskNotFound(`Task with id: ${id} not found`);
+        }
     }
 }

--- a/src/services/errors/TaskNotFound.ts
+++ b/src/services/errors/TaskNotFound.ts
@@ -1,0 +1,5 @@
+export default class TaskNotFound extends Error {
+    constructor(message: string) {
+        super(message);
+    }
+}


### PR DESCRIPTION
## Summary

This PR introduces the following key updates:
1. **Task Retrieval by ID**: Adds functionality to retrieve a task by its ID.
2. **Error Handling**: Improves error handling across the controllers and services, including the introduction of a custom `TaskNotFound` error.

## Changes

### 1. **TaskController Updates**
- Added a new `getTaskById` method to retrieve tasks by their unique ID.
- Updated error responses:
  - Changed error handling from sending `error.message` to sending the entire `error` object for more comprehensive error responses.
  - Added a `404 Not Found` response when a task is not found by its ID.